### PR TITLE
fix and alternative

### DIFF
--- a/src/kulprit/families.py
+++ b/src/kulprit/families.py
@@ -40,23 +40,15 @@ class Gaussian(Family):
         """Kullback-Leibler divergence between two Gaussians surrogate function.
 
         Args:
-            mu_ast (torch.tensor): Tensor of learned reference model parameters
-            mu_perp (torch.tensor): Tensor of submodel parameters to learn
+            y_ast (torch.tensor): Tensor of reference model posterior draws
+            y_perp (torch.tensor): Tensor of restricted model posterior draws
 
         Returns:
             torch.tensor: Tensor of shape () containing sample KL divergence
         """
-
-        # compute sufficient statistics
-        mu_ast, mu_perp = torch.mean(y_ast, 1), torch.mean(y_perp, 1)
-        std_ast, std_perp = torch.std(y_ast, 1), torch.std(y_perp, 1)
-        # compute KL divergence using full formula
-        div = torch.mean(
-            torch.log(std_perp / std_ast)
-            + (std_ast**2 + (mu_ast - mu_perp) ** 2) / (2 * std_perp**2)
-            - 0.5
-        )
-        #div = torch.mean((y_ast - y_perp)**2)
+        
+        # compute Wasserstein distance as a KL divergence surrogate
+        div = torch.mean((y_ast - y_perp) ** 2)
         assert div.shape == (), f"Expected data dimensions {()}, received {div.shape}."
         return div
 

--- a/src/kulprit/families.py
+++ b/src/kulprit/families.py
@@ -48,14 +48,15 @@ class Gaussian(Family):
         """
 
         # compute sufficient statistics
-        mu_ast, mu_perp = torch.mean(y_ast), torch.mean(y_perp)
-        std_ast, std_perp = torch.std(y_ast), torch.std(y_perp)
+        mu_ast, mu_perp = torch.mean(y_ast, 1), torch.mean(y_perp, 1)
+        std_ast, std_perp = torch.std(y_ast, 1), torch.std(y_perp, 1)
         # compute KL divergence using full formula
-        div = (
+        div = torch.mean(
             torch.log(std_perp / std_ast)
             + (std_ast**2 + (mu_ast - mu_perp) ** 2) / (2 * std_perp**2)
-            - 1 / 2
+            - 0.5
         )
+        #div = torch.mean((y_ast - y_perp)**2)
         assert div.shape == (), f"Expected data dimensions {()}, received {div.shape}."
         return div
 

--- a/src/kulprit/families.py
+++ b/src/kulprit/families.py
@@ -46,7 +46,7 @@ class Gaussian(Family):
         Returns:
             torch.tensor: Tensor of shape () containing sample KL divergence
         """
-        
+
         # compute Wasserstein distance as a KL divergence surrogate
         div = torch.mean((y_ast - y_perp) ** 2)
         assert div.shape == (), f"Expected data dimensions {()}, received {div.shape}."

--- a/src/kulprit/projection/project.py
+++ b/src/kulprit/projection/project.py
@@ -30,7 +30,9 @@ class Projector:
         family = Family.create(model.family.name)
         link = model.family.link
         response_name = model.response.name
-        predictions = model.predict(idata=posterior, inplace=False, kind="pps").posterior_predictive[response_name]
+        predictions = model.predict(
+            idata=posterior, inplace=False, kind="pps"
+        ).posterior_predictive[response_name]
         X = torch.from_numpy(model._design.common.design_matrix).float()
         y = torch.from_numpy(model._design.response.design_vector).float()
         data = model.data

--- a/src/kulprit/projection/project.py
+++ b/src/kulprit/projection/project.py
@@ -29,7 +29,8 @@ class Projector:
         # define key model attributes
         family = Family.create(model.family.name)
         link = model.family.link
-        predictions = model.predict(idata=posterior, inplace=False)
+        response_name = model.response.name
+        predictions = model.predict(idata=posterior, inplace=False, kind="pps").posterior_predictive[response_name]
         X = torch.from_numpy(model._design.common.design_matrix).float()
         y = torch.from_numpy(model._design.response.design_vector).float()
         data = model.data
@@ -81,6 +82,7 @@ class Projector:
 
         # build restricted model object
         res_model = _build_restricted_model(self.full_model, cov_names)
+
         # extract restricted design matrix
         X_perp = res_model.X
         # extract reference model posterior predictions

--- a/src/kulprit/utils.py
+++ b/src/kulprit/utils.py
@@ -43,9 +43,8 @@ def _extract_insample_predictions(model):
     """
 
     y_pred = (
-        torch.from_numpy(model.predictions.posterior.y_mean.values)
+        torch.from_numpy(model.predictions.stack(samples=("chain", "draw")).values.T)
         .float()
-        .reshape(model.s, model.n)
     )
     return y_pred
 

--- a/src/kulprit/utils.py
+++ b/src/kulprit/utils.py
@@ -42,10 +42,9 @@ def _extract_insample_predictions(model):
         torch.tensor: The in-sample predictions
     """
 
-    y_pred = (
-        torch.from_numpy(model.predictions.stack(samples=("chain", "draw")).values.T)
-        .float()
-    )
+    y_pred = torch.from_numpy(
+        model.predictions.stack(samples=("chain", "draw")).values.T
+    ).float()
     return y_pred
 
 


### PR DESCRIPTION
This PR introduces two changes

* Use posterior predictive samples instead of the posterior of mean function
* Compute the KL-divergence over samples and then average

Nevertheless, I want to use this PR to discuss the implications of the current approach. Assuming I am understanding it correctly, and possible alternatives.

With the changes in this PR, the result I get is this.

![index](https://user-images.githubusercontent.com/1338958/158622501-bd6b7b9f-60d0-426a-8fdd-332eb5db0f1a.png)

Which is not the expected result but makes sense given the current code (which is not taking into account that for a regression X-y comes in pairs). Thus, one alternative could be to compute instead the squared differences between the sorted posterior predictive distribution (this is similar to one Wasserstein distance) and is cheap given that the distributions are (kind of) already sorted.

At least for this example this provides solution that looks ok
![index](https://user-images.githubusercontent.com/1338958/158624003-8bb5b98a-acbe-4bea-84fc-aa23cc060ff9.png)



