### PR TITLE
Improve handling of dispersion transformed variables

### DIFF
--- a/src/kulprit/data/structure.py
+++ b/src/kulprit/data/structure.py
@@ -96,7 +96,7 @@ def get_transforms(model):
     transforms = {}
     for var in model.value_vars:
         name = var.name
-        transform_name = " "
+        transform_name = ""
         transform_function = None
         if is_transformed_name(name):
             name = get_untransformed_name(name)


### PR DESCRIPTION
Notice that this fix is restricted to dispersion parameters, transformation of other variables is still missing. But this should make simple to deal with those. Additionally, this prevents the transformed dispersion parameter to be added to the idata.