### PR TITLE
Project tuple

### DIFF
--- a/src/kulprit/reference.py
+++ b/src/kulprit/reference.py
@@ -74,14 +74,14 @@ class ReferenceModel:
 
     def project(
         self,
-        terms: Union[List[str], int],
+        terms: Union[List[str], Tuple[str], int],
     ) -> SubModel:
         """Projection the reference model onto a variable subset.
 
         Args:
-            terms (Union[List[str], int]): Either a list of strings containing
-                the names of the parameters to include the submodel, or the
-                number of parameters to include in the submodel, **not**
+            terms (Union[List[str], Tuple[str], int]): Collection of strings
+                containing the names of the parameters to include the submodel,
+                or the number of parameters to include in the submodel, **not**
                 including the intercept term
 
         Returns:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -136,6 +136,16 @@ class TestProjector(KulpritTest):
         submodel = ref_model_copy.project(terms=1)
         assert submodel.size == 1
 
+    def test_project_tuple(self, ref_model):
+        """Test that the projection method works for tuple input."""
+
+        # project the reference model to some parameter subset
+        ref_model_copy = copy.copy(ref_model)
+        ref_model_copy.search()
+        terms = tuple("x")
+        submodel = ref_model_copy.project(terms=terms)
+        assert submodel.size == 1
+
     def test_project_too_many_terms(self, ref_model):
         """Test that the projection method raises an error for too many terms."""
 


### PR DESCRIPTION
## Description

Allow the `project` method to accept the collection of submodel term names as a tuple. Closes #30.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
